### PR TITLE
Depend on GMS base instead of location

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ android {
 }
 
 dependencies {
-    api 'com.google.android.gms:play-services-location:17.0.0'
+    implementation 'com.google.android.gms:play-services-base:17.2.1'
     implementation 'androidx.annotation:annotation:1.1.0'
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Enhancement

### :arrow_heading_down: What is the current behavior?

Plugin depends on GMS location component & exposes it into classpath

### :new: What is the new behavior (if this is a feature change)?

Depend on the base package only, keep it in the plugin class path

### :boom: Does this PR introduce a breaking change?

No

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop