### PR TITLE
Add platform interface

### DIFF
--- a/google_api_availability_platform_interface/CHANGELOG.md
+++ b/google_api_availability_platform_interface/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial release.

--- a/google_api_availability_platform_interface/LICENSE
+++ b/google_api_availability_platform_interface/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Baseflow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/google_api_availability_platform_interface/README.md
+++ b/google_api_availability_platform_interface/README.md
@@ -1,0 +1,42 @@
+# google_api_availability_platform_interface
+
+[![style: flutter_lints](https://img.shields.io/badge/style-flutter_lints-40c4ff.svg)](https://pub.dev/packages/flutter_lints)
+
+A common platform interface for the [`google_api_availability`][1] plugin.
+
+This interface allows platform-specific implementations of the `google_api_availability`
+plugin, as well as the plugin itself, to ensure they are supporting the
+same interface. Have a look at the [Federated plugins](https://flutter.dev/docs/development/packages-and-plugins/developing-packages#federated-plugins) 
+section of the official [Developing packages & plugins](https://flutter.dev/docs/development/packages-and-plugins/developing-packages) 
+documentation for more information regarding the federated architecture concept. 
+
+## Usage
+
+To implement a new platform-specific implementation of `google_api_availability`, extend
+[`GoogleApiAvailabilityPlatform`][2] with an implementation that performs the
+platform-specific behavior, and when you register your plugin, set the default
+`GoogleApiAvailabilityPlatform` by calling
+`GoogleApiAvailabilityPlatform.instance = MyGoogleApiAvailabilityPlatform()`.
+
+## Note on breaking changes
+
+Strongly prefer non-breaking changes (such as adding a method to the interface)
+over breaking changes for this package.
+
+See https://flutter.dev/go/platform-interface-breaking-changes for a discussion
+on why a less-clean interface is preferable to a breaking change.
+
+## Issues
+
+Please file any issues, bugs or feature requests as an issue on our [GitHub](https://github.com/Baseflow/flutter-google-api-availability/issues) page. Commercial support is available, you can contact us at <hello@baseflow.com>.
+
+## Want to contribute
+
+If you would like to contribute to the plugin (e.g. by improving the documentation, solving a bug or adding a cool new feature), please carefully review our [contribution guide](../CONTRIBUTING.md) and send us your [pull request](https://github.com/Baseflow/flutter-google-api-availability/pulls).
+
+## Author
+
+This Google API Availability plugin for Flutter is developed by [Baseflow](https://baseflow.com).
+
+[1]: ../google_api_availability
+[2]: lib/google_api_availability_platform_interface.dart

--- a/google_api_availability_platform_interface/analysis_options.yaml
+++ b/google_api_availability_platform_interface/analysis_options.yaml
@@ -1,0 +1,10 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'
+linter:
+  rules:
+    - public_member_api_docs

--- a/google_api_availability_platform_interface/lib/google_api_availability_platform_interface.dart
+++ b/google_api_availability_platform_interface/lib/google_api_availability_platform_interface.dart
@@ -1,0 +1,4 @@
+library google_api_availability_platform_interface;
+
+export 'src/google_api_availability_platform_interface.dart';
+export 'src/models/google_play_services_availability.dart';

--- a/google_api_availability_platform_interface/lib/src/google_api_availability_platform_interface.dart
+++ b/google_api_availability_platform_interface/lib/src/google_api_availability_platform_interface.dart
@@ -1,0 +1,95 @@
+import 'package:google_api_availability_platform_interface/google_api_availability_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'implementations/method_channel_google_api_availability.dart';
+
+/// The interface that implementations of `google_api_availability` must implement.
+///
+/// Platform implementations should extend this class rather than implement it
+/// as `google_api_availability` does not consider newly added methods to be
+/// breaking changes. Extending this class (using `extends`) ensures that the
+/// subclass will get the default implementation, while platform implementations
+/// that `implements` this interface will be broken by newly added
+/// [GoogleApiAvailabilityPlatform] methods.
+abstract class GoogleApiAvailabilityPlatform extends PlatformInterface {
+  /// Constructs a [GoogleApiAvailabilityPlatform].
+  GoogleApiAvailabilityPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static GoogleApiAvailabilityPlatform _instance =
+      MethodChannelGoogleApiAvailability();
+
+  /// The default instance of [GoogleApiAvailabilityPlatform] to use.
+  ///
+  /// Defaults to [MethodChannelGoogleApiAvailability].
+  static GoogleApiAvailabilityPlatform get instance => _instance;
+
+  /// Platform-specific plugins should set this with their own platform-specific
+  /// class that extends [GoogleApiAvailabilityPlatform] when they register
+  /// themselves.
+  static set instance(GoogleApiAvailabilityPlatform instance) {
+    PlatformInterface.verify(instance, _token);
+    _instance = instance;
+  }
+
+  /// Returns the connection status of Google Play Service.
+  ///
+  /// Optionally, you can also show an error dialog if the connection status is
+  /// not [GooglePlayServicesAvailability.success].
+  Future<GooglePlayServicesAvailability> checkGooglePlayServicesAvailability([
+    bool showDialogIfNecessary = false,
+  ]) {
+    throw UnimplementedError(
+      'checkGooglePlayServicesAvailability() has not been implemented.',
+    );
+  }
+
+  /// Attempts to make Google Play Services available on this device.
+  ///
+  /// Shows a dialog if the error is resolvable by user.
+  /// If the `Future` completes without throwing an exception, Play Services
+  /// is available on this device.
+  Future<void> makeGooglePlayServicesAvailable() {
+    throw UnimplementedError(
+      'makeGooglePlayServicesAvailable() has not been implemented.',
+    );
+  }
+
+  /// Returns a human-readable string of the error code.
+  Future<String> getErrorString() {
+    throw UnimplementedError(
+      'getErrorString() has not been implemented.',
+    );
+  }
+
+  /// Determines whether an error can be resolved via user action.
+  Future<bool> isUserResolvable() {
+    throw UnimplementedError(
+      'isUserResolvable() has not been implemented.',
+    );
+  }
+
+  /// Displays a notification for an error code, if it is resolvable by the user.
+  ///
+  /// This method is similar to [showErrorDialogFragment], but is provided for
+  /// background tasks that cannot or should not display dialogs.
+  Future<void> showErrorNotification() {
+    throw UnimplementedError(
+      'showErrorNotification() has not been implemented.',
+    );
+  }
+
+  /// Display an error dialog according to the [ErrorCode] if the connection
+  /// status is not [GooglePlayServicesAvailability.success].
+  ///
+  /// Returns true if the connection status did not equal
+  /// [GooglePlayServicesAvailability.success] or any other
+  /// non-[ConnectionResult] value.
+  /// Returns false otherwise.
+  Future<bool> showErrorDialogFragment() {
+    throw UnimplementedError(
+      'showErrorDialogFragment() has not been implemented.',
+    );
+  }
+}

--- a/google_api_availability_platform_interface/lib/src/implementations/method_channel_google_api_availability.dart
+++ b/google_api_availability_platform_interface/lib/src/implementations/method_channel_google_api_availability.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import '../google_api_availability_platform_interface.dart';
+import '../models/google_play_services_availability.dart';
+
+/// An implementation of [GoogleApiAvailabilityPlatform] that uses method channels.
+class MethodChannelGoogleApiAvailability extends GoogleApiAvailabilityPlatform {
+  /// The method channel used to interact with the native platform.
+  static const _methodChannel =
+      MethodChannel('flutter.baseflow.com/google_api_availability');
+
+  @override
+  Future<GooglePlayServicesAvailability> checkGooglePlayServicesAvailability([
+    bool showDialogIfNecessary = false,
+  ]) async {
+    final parameters = <String, bool>{
+      'showDialogIfNecessary': showDialogIfNecessary,
+    };
+
+    final availability = await _methodChannel.invokeMethod(
+      'checkGooglePlayServicesAvailability',
+      parameters,
+    );
+
+    if (availability == null) {
+      return GooglePlayServicesAvailability.unknown;
+    }
+
+    return GooglePlayServicesAvailability.values[availability];
+  }
+
+  @override
+  Future<void> makeGooglePlayServicesAvailable() async {
+    await _methodChannel.invokeMethod('makeGooglePlayServicesAvailable');
+  }
+
+  @override
+  Future<String> getErrorString() async {
+    final errorString = await _methodChannel.invokeMethod('getErrorString');
+
+    if (errorString == null) {
+      return 'ErrorString is null';
+    }
+
+    return errorString;
+  }
+
+  @override
+  Future<bool> isUserResolvable() async {
+    final isUserResolvable =
+        await _methodChannel.invokeMethod('isUserResolvable');
+
+    if (isUserResolvable == null) {
+      return false;
+    }
+
+    return isUserResolvable;
+  }
+
+  @override
+  Future<void> showErrorNotification() async {
+    await _methodChannel.invokeMethod('showErrorNotification');
+  }
+
+  @override
+  Future<bool> showErrorDialogFragment() async {
+    final showErrorDialogFragment =
+        await _methodChannel.invokeMethod('showErrorDialogFragment');
+
+    if (showErrorDialogFragment == null) {
+      return false;
+    }
+
+    return showErrorDialogFragment;
+  }
+}

--- a/google_api_availability_platform_interface/lib/src/models/google_play_services_availability.dart
+++ b/google_api_availability_platform_interface/lib/src/models/google_play_services_availability.dart
@@ -1,0 +1,78 @@
+import 'package:meta/meta.dart';
+
+/// Indicates possible states of the Google Api Services availability.
+class GooglePlayServicesAvailability {
+  const GooglePlayServicesAvailability._(this.value);
+
+  /// Returns the value of the status as a string of the given status integer
+  factory GooglePlayServicesAvailability.byValue(int value) => values[value];
+
+  /// Creates an instance of the [GooglePlayServicesAvailability] class. This
+  /// constructor is exposed for testing purposes only and should not be used
+  /// by clients of the plugin as it may break or change at any time.
+  @visibleForTesting
+  const GooglePlayServicesAvailability.private(this.value);
+
+  /// Represents the integer value of the Google Api Services availability
+  /// state.
+  final int value;
+
+  /// Google Play services are installed on the device and ready to be used.
+  static const GooglePlayServicesAvailability success =
+      GooglePlayServicesAvailability._(0);
+
+  /// Google Play services is missing on this device.
+  static const GooglePlayServicesAvailability serviceMissing =
+      GooglePlayServicesAvailability._(1);
+
+  /// Google Play service is currently being updated on this device.
+  static const GooglePlayServicesAvailability serviceUpdating =
+      GooglePlayServicesAvailability._(2);
+
+  /// The installed version of Google Play services is out of date.
+  static const GooglePlayServicesAvailability serviceVersionUpdateRequired =
+      GooglePlayServicesAvailability._(3);
+
+  /// The installed version of Google Play services has been disabled on this device.
+  static const GooglePlayServicesAvailability serviceDisabled =
+      GooglePlayServicesAvailability._(4);
+
+  /// The version of the Google Play services installed on this device is not authentic.
+  static const GooglePlayServicesAvailability serviceInvalid =
+      GooglePlayServicesAvailability._(5);
+
+  /// Google Play services are not available on this platform.
+  static const GooglePlayServicesAvailability notAvailableOnPlatform =
+      GooglePlayServicesAvailability._(6);
+
+  /// Unable to determine if Google Play services are installed.
+  static const GooglePlayServicesAvailability unknown =
+      GooglePlayServicesAvailability._(7);
+
+  /// Returns a list with all possible Google Api Availability states.
+  static const List<GooglePlayServicesAvailability> values =
+      <GooglePlayServicesAvailability>[
+    success,
+    serviceMissing,
+    serviceUpdating,
+    serviceVersionUpdateRequired,
+    serviceDisabled,
+    serviceInvalid,
+    notAvailableOnPlatform,
+    unknown,
+  ];
+
+  static const List<String> _names = <String>[
+    'success',
+    'serviceMissing',
+    'serviceUpdating',
+    'serviceVersionUpdateRequired',
+    'serviceDisabled',
+    'serviceInvalid',
+    'notAvailableOnPlatform',
+    'unknown',
+  ];
+
+  @override
+  String toString() => 'GooglePlayServicesAvailability.${_names[value]}';
+}

--- a/google_api_availability_platform_interface/pubspec.yaml
+++ b/google_api_availability_platform_interface/pubspec.yaml
@@ -1,0 +1,22 @@
+name: google_api_availability_platform_interface
+description: A common platform interface for the google_api_availability plugin.
+repository: https://github.com/baseflow/flutter-google-api-availability/tree/main/google_api_availability_platform_interface
+# NOTE: We strongly prefer non-breaking changes, even at the expense of a
+# less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
+version: 1.0.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+  plugin_platform_interface: ^2.1.4
+  meta: ^1.8.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.1
+  mockito: ^5.3.2
+
+environment:
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"

--- a/google_api_availability_platform_interface/test/google_api_availability_platform_interface_test.dart
+++ b/google_api_availability_platform_interface/test/google_api_availability_platform_interface_test.dart
@@ -1,0 +1,142 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_api_availability_platform_interface/google_api_availability_platform_interface.dart';
+import 'package:google_api_availability_platform_interface/src/implementations/method_channel_google_api_availability.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('$GoogleApiAvailabilityPlatform', () {
+    test('$MethodChannelGoogleApiAvailability is the default instance', () {
+      expect(GoogleApiAvailabilityPlatform.instance,
+          isA<MethodChannelGoogleApiAvailability>());
+    });
+
+    test('Cannot be implemented with `implements`', () {
+      expect(() {
+        GoogleApiAvailabilityPlatform.instance =
+            ImplementsGoogleApiAvailabilityPlatform();
+        // In versions of `package:plugin_platform_interface` prior to fixing
+        // https://github.com/flutter/flutter/issues/109339, an attempt to
+        // implement a platform interface using `implements` would sometimes
+        // throw a `NoSuchMethodError` and other times throw an
+        // `AssertionError`.  After the issue is fixed, an `AssertionError` will
+        // always be thrown.  For the purpose of this test, we don't really care
+        // what exception is thrown, so just allow any exception.
+      }, throwsA(anything));
+    });
+
+    test('Can be extended', () {
+      GoogleApiAvailabilityPlatform.instance =
+          ExtendsGoogleApiAvailabilityPlatform();
+    });
+
+    test('Can be mocked with `implements`', () {
+      final mock = MockGoogleApiAvailabilityPlatform();
+      GoogleApiAvailabilityPlatform.instance = mock;
+    });
+
+    test(
+        'Default implementation of checkGooglePlayServicesAvailability should throw unimplemented error',
+        () {
+      // Arrange
+      final googleApiAvailabilityPlatform =
+          ExtendsGoogleApiAvailabilityPlatform();
+
+      // Act & Assert
+      expect(
+        () =>
+            googleApiAvailabilityPlatform.checkGooglePlayServicesAvailability(),
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
+        'Default implementation of makeGooglePlayServicesAvailable should throw unimplemented error',
+        () {
+      // Arrange
+      final googleApiAvailabilityPlatform =
+          ExtendsGoogleApiAvailabilityPlatform();
+
+      // Act & Assert
+      expect(
+        () => googleApiAvailabilityPlatform.makeGooglePlayServicesAvailable(),
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
+        'Default implementation of getErrorString should throw unimplemented error',
+        () {
+      // Arrange
+      final googleApiAvailabilityPlatform =
+          ExtendsGoogleApiAvailabilityPlatform();
+
+      // Act & Assert
+      expect(
+        () => googleApiAvailabilityPlatform.getErrorString(),
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
+        'Default implementation of isUserResolvable should throw unimplemented error',
+        () {
+      // Arrange
+      final googleApiAvailabilityPlatform =
+          ExtendsGoogleApiAvailabilityPlatform();
+
+      // Act & Assert
+      expect(
+        () => googleApiAvailabilityPlatform.isUserResolvable(),
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
+        'Default implementation of showErrorNotification should throw unimplemented error',
+        () {
+      // Arrange
+      final googleApiAvailabilityPlatform =
+          ExtendsGoogleApiAvailabilityPlatform();
+
+      // Act & Assert
+      expect(
+        () => googleApiAvailabilityPlatform.showErrorNotification(),
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
+        'Default implementation of showErrorDialogFragment should throw unimplemented error',
+        () {
+      // Arrange
+      final googleApiAvailabilityPlatform =
+          ExtendsGoogleApiAvailabilityPlatform();
+
+      // Act & Assert
+      expect(
+        () => googleApiAvailabilityPlatform.showErrorDialogFragment(),
+        throwsUnimplementedError,
+      );
+    });
+  });
+}
+
+class ImplementsGoogleApiAvailabilityPlatform
+    implements GoogleApiAvailabilityPlatform {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class MockGoogleApiAvailabilityPlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements GoogleApiAvailabilityPlatform {}
+
+class ExtendsGoogleApiAvailabilityPlatform
+    extends GoogleApiAvailabilityPlatform {}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR adds a platform interface for the plugin. This interface is part of the ongoing effort to refactor the code to use the federated plugin architecture. The `GooglePlayServicesAvailability` model has been copied over, and its original version will be removed in a later PR.

### :arrow_heading_down: What is the current behavior?

The plugin uses a non-federated architecture.

### :new: What is the new behavior (if this is a feature change)?

The plugin will function the same. The platform interface code is contained in the new directory `/google-api-availability-platform-interface` and is not used outside of it.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

This PR adds tests for the newly added `GoogleApiAvailabilityPlatform`. These tests can be found in `google-api-availability-platform-interface/test/google_api_availability_platform_interface_test.dart`.

### :memo: Links to relevant issues/docs

This PR is part of the ongoing effort to refactor this plugin to use the federated architecture requested in #33.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop