### PR TITLE
Fixes Android pubspec

### DIFF
--- a/google_api_availability_android/CHANGELOG.md
+++ b/google_api_availability_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0+1
+
+* Declares `dartPluginClass` in pubspec declaration.
+
 ## 1.0.0
 
 * Extracts the Android platform implementation from the google_api_availability package.

--- a/google_api_availability_android/pubspec.yaml
+++ b/google_api_availability_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: An Android implementation for the google_api_availability plugin.
 repository: https://github.com/baseflow/flutter-google-api-availability/tree/main/google_api_availability_android
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.0.0+1
 
 flutter:
   plugin:
@@ -12,6 +12,7 @@ flutter:
       android:
         package: com.baseflow.googleapiavailability
         pluginClass: GoogleApiAvailabilityPlugin
+        dartPluginClass: GoogleApiAvailabilityAndroid
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds the `dartPluginClass` declaration to the pubspec.

### :boom: Does this PR introduce a breaking change?
No.

### :memo: Links to relevant issues/docs
This PR is part of the journey to transitioning to the federated plugin architecture. See #33.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop