### PR TITLE
added namespace for AGP8 compatibility

### DIFF
--- a/google_api_availability/example/android/app/build.gradle
+++ b/google_api_availability/example/android/app/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'com.baseflow.googleapiavailabilityexample'
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/google_api_availability/example/android/app/src/main/AndroidManifest.xml
+++ b/google_api_availability/example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.baseflow.googleapiavailabilityexample">
-
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/google_api_availability/example/android/build.gradle
+++ b/google_api_availability/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.3.0'
     }
 }
 
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/google_api_availability/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/google_api_availability/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/google_api_availability_android/CHANGELOG.md
+++ b/google_api_availability_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1
 
-* Add support of namespace property to support Android Gradle Plugin (AGP) 8
+* Adds support for the namespace property to support Android Gradle Plugin (AGP) 8.
 
 ## 1.0.0+1
 

--- a/google_api_availability_android/CHANGELOG.md
+++ b/google_api_availability_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Add support of namespace property to support Android Gradle Plugin (AGP) 8
+
 ## 1.0.0+1
 
 * Declares `dartPluginClass` in pubspec declaration.

--- a/google_api_availability_android/android/build.gradle
+++ b/google_api_availability_android/android/build.gradle
@@ -22,6 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.baseflow.googleapiavailability'
+    }
+
     compileSdkVersion 31
 
     compileOptions {

--- a/google_api_availability_android/pubspec.yaml
+++ b/google_api_availability_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: An Android implementation for the google_api_availability plugin.
 repository: https://github.com/baseflow/flutter-google-api-availability/tree/main/google_api_availability_android
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0+1
+version: 1.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
adding namespace in `build.gradle` for compatibility with AGP 8

### :arrow_heading_down: What is the current behavior?
no behaviour change

### :new: What is the new behavior (if this is a feature change)?
no behaviour change

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
use AGP 8

### :memo: Links to relevant issues/docs
cf Flutter packages comment/solution:
- https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b
- https://github.com/flutter/packages/commit/a86beafa8912609275225847198c9c0164957d09

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-google-api-availability/blob/main/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
